### PR TITLE
Corrects setup of coverage tool reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
       "example",
       "dist",
       "coverage"
-    ]
+    ],
+    "all": true
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "tsc -w",
     "test": "mocha",
     "test:watch": "mocha --watch --watch-extensions ts",
-    "test:coverage": "nyc -e '.ts' -r lcov -r text npm run test",
+    "test:coverage": "nyc -r lcov -r text npm run test",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "prepublish": "npm run lint && npm run test && npm run build"
   },
@@ -19,6 +19,23 @@
   "repository": {
     "type": "git",
     "url": "https://github.com:rthewhite/rmicroservice.git"
+  },
+  "nyc": {
+    "extension": [
+      ".ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "exclude": [
+      "test",
+      "test{,-*}.js",
+      "**/*.test.js",
+      "**/__tests__/**",
+      "**/node_modules/**",
+      "example"
+    ],
+    "all": true
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
       "**/*.test.js",
       "**/__tests__/**",
       "**/node_modules/**",
-      "example"
-    ],
-    "all": true
+      "example",
+      "dist",
+      "coverage"
+    ]
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",


### PR DESCRIPTION
This forces `nyc` to report coverage on all testable files. Expecting the coverage to drop to 50% from this point on.

Related to https://github.com/istanbuljs/nyc/issues/618